### PR TITLE
Add escrow timeout mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ A decentralized marketplace for artisans and crafters to list and sell their han
   - Buyer funds held in escrow until approval
   - Seller protection with secure fund release
   - Refund capability for dispute resolution
+  - Automatic escrow expiration after 24 hours
+  - Anyone can trigger refund of expired escrows
 
 ## Getting Started
 1. Clone the repository
@@ -37,3 +39,5 @@ The marketplace includes a secure escrow system to protect both buyers and selle
 3. Upon receiving and approving the item, buyer releases the escrow
 4. Seller can initiate refund if needed
 5. Platform fee is automatically handled during escrow release
+6. Escrows automatically expire after 24 hours
+7. Anyone can trigger refund of expired escrows to protect buyers


### PR DESCRIPTION
This PR introduces an automatic timeout mechanism for escrows to protect buyers from unresponsive sellers. Key changes:

- Added 24-hour timeout period for escrows (144 blocks)
- New error constant `err-escrow-expired` for expired escrows
- Modified `release-escrow` to check for expiration
- Enhanced `refund-escrow` to allow anyone to refund expired escrows
- Added helper function `is-escrow-expired`
- Added new test case for expired escrow refunds
- Updated documentation with timeout feature details

The timeout feature adds an important safety mechanism that:
- Prevents funds from being locked indefinitely
- Protects buyers from unresponsive sellers
- Allows community assistance in refunding expired escrows
- Maintains existing functionality for active escrows

Testing:
- All existing tests pass
- Added new test case for expired escrow scenario
- Manually tested timeout periods and refund mechanisms

This enhancement improves the marketplace's security and user experience without breaking existing functionality.